### PR TITLE
change supported version of `django-cms` everywhere

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django CMS",
-    "Framework :: Django CMS :: 3.11",
     "Framework :: Django CMS :: 4.0",
     "Framework :: Django CMS :: 4.1",
     "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     ruff
     frontend
-    py{310,311,312}-dj{42}-cms{311,41}
-    py{310,311,312}-dj{50}-cms{311,41}
+    py{310,311,312}-dj{42}-cms{40,41}
+    py{310,311,312}-dj{50}-cms{40,41}
 
 skip_missing_interpreters=True
 
@@ -14,9 +14,8 @@ deps =
     dj50: Django>=5.0,<5.1
     dj51: Django>=5.1,<5.2
     dj52: Django>=5.2,<6.0
-    cms311: django-cms>=3.11,<4
     cms40: git+https://github.com/django-cms/django-cms@release/4.0.1.x
-    cms41: git+https://github.com/django-cms/django-cms@develop-4
+    cms41: django-cms>=4.1,<4.2
 
 commands =
     {envpython} --version


### PR DESCRIPTION
The project does not run on `djang-cms<4` in it's current form.