### PR TITLE
fix: Page serializer returned null for empty mets_description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,6 @@ version = {attr = "djangocms_rest.__version__"}
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["djangocms_rest*"]
+
+[tool.ruff]
+line-length = 119


### PR DESCRIPTION
Fixes #54:

For the page serializer:
* `meta_description` needs to return a string if the field is null
* `redirect` needs to return a string if the field is null


