### PR TITLE
fix: add preview query parameter to page detail OpenAPI schema

### DIFF
--- a/djangocms_rest/views.py
+++ b/djangocms_rest/views.py
@@ -138,6 +138,7 @@ class PageTreeListView(BaseAPIView):
         return Response(serializer.data)
 
 
+@preview_schema
 @menu_schema_class
 class PageDetailView(BaseAPIView):
     permission_classes = [IsAllowedPublicLanguage, CanViewPage]

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -281,10 +281,13 @@ class OpenAPISchemaTestCase(RESTTestCase):
                 if not has_preview:
                     missing_preview.append(path)
 
-        # This is informational - some endpoints might not need preview
-        # So we just check that at least some have it
-        if preview_endpoints and len(missing_preview) == len(preview_endpoints):
-            self.fail(f"No preview parameter found in any of the relevant endpoints: {preview_endpoints}")
+        # All page and placeholder endpoints support previewing unpublished
+        # content, so every one of them must document the preview parameter.
+        if missing_preview:
+            self.fail(
+                "The 'preview' query parameter is missing from these endpoints: "
+                + ", ".join(missing_preview)
+            )
 
     def test_menu_schema_get_operation_id_with_url_name_on_class(self):
         """Test MenuSchema.get_operation_id when _url_name is set on view class (not instance)."""


### PR DESCRIPTION
## Problem

The generated OpenAPI schema was missing the `?preview=true` query parameter on the page detail endpoints:

- `/api/{language}/pages/`
- `/api/{language}/pages/{path}/`

Both endpoints support previewing unpublished content (they use `content_getter`/`_preview_requested`), but the parameter was not documented.

## Root cause

`@preview_schema` (an `extend_schema(...)`) is applied to `BaseAPIMixin`, which sets a `schema` attribute that subclasses inherit — this is why `PageListView` and `PageTreeListView` correctly expose `preview`.

`PageDetailView` is additionally decorated with `@menu_schema_class`, which sets `schema = MenuSchema()` and **overrides** the inherited schema, dropping the `preview` parameter. `MenuView` avoids this by stacking `@preview_schema` on top of `@menu_schema_class`.

## Fix

Stack `@preview_schema` on top of `@menu_schema_class` for `PageDetailView` (mirroring `MenuView`). drf-spectacular's `ExtendedSchema` then wraps `MenuSchema`, preserving **both** the custom `operation_id` and the `preview` parameter.

No new mandatory dependency: `preview_schema` already has a no-op fallback in `views_base.py`, so drf-spectacular remains optional.

## Tests

Tightened `test_preview_parameter_documented` to require the `preview` parameter on **every** page/placeholder endpoint (previously it only failed if *all* endpoints were missing it). Verified this stricter test fails without the view change and passes with it.

## Summary by Sourcery

Ensure page detail OpenAPI schemas document preview support while preserving their custom operation metadata.

Bug Fixes:
- Document the `preview` query parameter for the page detail OpenAPI endpoint.

Enhancements:
- Require all page and placeholder endpoints that support unpublished-content previews to expose the `preview` parameter in the OpenAPI schema.

Tests:
- Strengthen OpenAPI schema coverage to fail when any supported page or placeholder endpoint omits the `preview` parameter.